### PR TITLE
feat(US-4): smart API spec reading and auto-injection

### DIFF
--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -1,8 +1,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import axios from 'axios';
+import { parse as parseYaml } from 'yaml';
 import { parseArgs } from './parse-args';
-import { parseOpenAPISpec } from '../../lib/parser/swagger';
-import { parsePostmanCollection } from '../../lib/parser/postman';
+import { parseOpenAPISpec, parseOpenAPIStructured } from '../../lib/parser/swagger';
+import { parsePostmanCollection, parsePostmanStructured } from '../../lib/parser/postman';
+import { writeStructuredKnowledge } from '../../lib/parser/knowledge-writer';
+import { knowledgeToMarkdown } from '../../lib/parser/swagger';
 import { loadConfig } from '../../lib/config';
 
 export async function importSpec(args: string[]): Promise<void> {
@@ -14,38 +18,138 @@ export async function importSpec(args: string[]): Promise<void> {
   }
 
   if (opts.postman) {
-    await importFile(opts.postman, 'postman', outputDir);
+    await importSource(opts.postman, 'postman', outputDir);
   } else if (opts.openapi) {
-    await importFile(opts.openapi, 'openapi', outputDir);
+    await importSource(opts.openapi, 'openapi', outputDir);
   } else {
-    console.log('Usage: anvil import --postman <file> | --openapi <file> [--output <dir>]');
+    // Check for positional URL argument (first non-flag arg)
+    const positional = args.find(a => !a.startsWith('--') && (a.startsWith('http://') || a.startsWith('https://')));
+    if (positional) {
+      await importSource(positional, 'auto', outputDir);
+    } else {
+      console.log('Usage: anvil import --postman <file|url> | --openapi <file|url> | <url>');
+      console.log('       anvil import https://api.example.com/openapi.json');
+    }
   }
 }
 
-async function importFile(filePath: string, type: 'postman' | 'openapi', outputDir: string): Promise<void> {
-  const resolved = path.resolve(filePath);
-  if (!fs.existsSync(resolved)) {
-    console.error(`❌ File not found: ${resolved}`);
-    process.exit(1);
+async function importSource(source: string, type: 'postman' | 'openapi' | 'auto', outputDir: string): Promise<void> {
+  let filePath: string;
+  let baseName: string;
+
+  if (source.startsWith('http://') || source.startsWith('https://')) {
+    console.log(`🌐 Fetching spec from: ${source}`);
+    const { tmpFile, detectedType, name } = await fetchAndDetect(source, type);
+    filePath = tmpFile;
+    baseName = name;
+    if (type === 'auto') type = detectedType;
+  } else {
+    filePath = path.resolve(source);
+    if (!fs.existsSync(filePath)) {
+      console.error(`❌ File not found: ${filePath}`);
+      process.exit(1);
+    }
+    baseName = path.basename(filePath, path.extname(filePath));
+    if (type === 'auto') {
+      type = detectFormatFromFile(filePath);
+    }
   }
 
   const icon = type === 'postman' ? '📦' : '📄';
-  console.log(`${icon} Parsing ${type === 'postman' ? 'Postman collection' : 'OpenAPI spec'}: ${resolved}`);
+  console.log(`${icon} Parsing ${type === 'postman' ? 'Postman collection' : 'OpenAPI spec'}: ${filePath}`);
 
   try {
+    // Generate structured knowledge
+    const knowledge =
+      type === 'postman'
+        ? await parsePostmanStructured(filePath)
+        : await parseOpenAPIStructured(filePath);
+
+    // Write structured JSON
+    writeStructuredKnowledge(knowledge, outputDir);
+    console.log(`📊 Structured knowledge written (endpoints.json, auth.json, schemas.json)`);
+
+    // Write markdown for human readability
     const markdown =
       type === 'postman'
-        ? await parsePostmanCollection(resolved)
-        : await parseOpenAPISpec(resolved);
+        ? await parsePostmanCollection(filePath)
+        : knowledgeToMarkdown(knowledge);
 
-    const baseName = path.basename(resolved, path.extname(resolved));
     const outputFile = path.join(outputDir, `${baseName}.md`);
     fs.writeFileSync(outputFile, markdown, 'utf-8');
     console.log(`✅ Knowledge base written to: ${outputFile}`);
     console.log(`   ${markdown.split('\n').length} lines, ${(markdown.length / 1024).toFixed(1)}KB`);
+    console.log(`   ${knowledge.endpoints.length} endpoints, ${knowledge.auth.length} auth schemes`);
   } catch (err: any) {
     console.error(`❌ Failed to parse: ${err.message}`);
     process.exit(1);
+  }
+}
+
+async function fetchAndDetect(
+  url: string,
+  hintType: 'postman' | 'openapi' | 'auto',
+): Promise<{ tmpFile: string; detectedType: 'postman' | 'openapi'; name: string }> {
+  const response = await axios.get(url, { responseType: 'text', timeout: 30000 });
+  let data = response.data;
+  let name = 'api-spec';
+
+  // Try to extract a name from the URL
+  const urlPath = new URL(url).pathname;
+  const urlBaseName = path.basename(urlPath, path.extname(urlPath));
+  if (urlBaseName && urlBaseName !== '') name = urlBaseName;
+
+  // Parse if YAML
+  let parsed: any;
+  if (typeof data === 'string' && (data.trim().startsWith('{') || data.trim().startsWith('['))) {
+    parsed = JSON.parse(data);
+  } else if (typeof data === 'string') {
+    // Might be YAML
+    try {
+      parsed = parseYaml(data);
+    } catch {
+      parsed = data;
+    }
+  } else {
+    parsed = data;
+  }
+
+  // Auto-detect type
+  let detectedType: 'postman' | 'openapi' = 'openapi';
+  if (hintType !== 'auto') {
+    detectedType = hintType;
+  } else if (parsed?.info?.schema?.includes('postman')) {
+    detectedType = 'postman';
+  } else if (parsed?.openapi || parsed?.swagger || parsed?.paths) {
+    detectedType = 'openapi';
+  } else if (parsed?.item) {
+    detectedType = 'postman';
+  }
+
+  if (parsed?.info?.title) {
+    name = parsed.info.title.replace(/[^a-zA-Z0-9-_]/g, '-').toLowerCase();
+  }
+
+  // Write to temp file
+  const tmpDir = path.join(require('os').tmpdir(), 'anvil-import');
+  fs.mkdirSync(tmpDir, { recursive: true });
+  const ext = detectedType === 'postman' ? '.json' : '.json';
+  const tmpFile = path.join(tmpDir, `${name}${ext}`);
+  fs.writeFileSync(tmpFile, typeof parsed === 'object' ? JSON.stringify(parsed, null, 2) : data, 'utf-8');
+
+  return { tmpFile, detectedType, name };
+}
+
+function detectFormatFromFile(filePath: string): 'postman' | 'openapi' {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const parsed = filePath.endsWith('.yaml') || filePath.endsWith('.yml')
+      ? parseYaml(raw)
+      : JSON.parse(raw);
+    if (parsed?.info?.schema?.includes('postman') || parsed?.item) return 'postman';
+    return 'openapi';
+  } catch {
+    return 'openapi';
   }
 }
 

--- a/src/lib/agent/core.ts
+++ b/src/lib/agent/core.ts
@@ -1,8 +1,9 @@
-import { LLMAdapter, LLMMessage, ToolCall } from '../adapters/interface';
+import { LLMAdapter, LLMMessage } from '../adapters/interface';
 import { TOOLS } from '../tools/definitions';
 import { handleToolCall, ToolContext } from '../tools/handlers';
 import { StepCallback, StepEntry } from '../step-log';
 import { SYSTEM_PROMPT } from './prompts';
+import { buildKnowledgeSummary } from './knowledge-injector';
 
 export interface AgentConfig {
   baseUrl: string;
@@ -39,7 +40,18 @@ export class AgentCore {
   }
 
   private buildSystemPrompt(): string {
-    return SYSTEM_PROMPT;
+    let prompt = SYSTEM_PROMPT;
+
+    // Auto-inject API knowledge if available
+    if (this.toolContext.knowledgeDir) {
+      const summary = buildKnowledgeSummary(this.toolContext.knowledgeDir);
+      if (summary) {
+        prompt += '\n\n---\n\n# API Knowledge Base (Auto-injected)\n\n' + summary;
+        prompt += '\n\nThe above endpoints are available in the target API. Use `read_knowledge` only if you need detailed schema information for request/response bodies.';
+      }
+    }
+
+    return prompt;
   }
 
   async run(userInput: string): Promise<AgentRunResult> {

--- a/src/lib/agent/knowledge-injector.ts
+++ b/src/lib/agent/knowledge-injector.ts
@@ -1,0 +1,52 @@
+import { loadStructuredKnowledge } from '../parser/knowledge-writer';
+import { StructuredKnowledge } from '../parser/types';
+
+/** Build a summary of the API knowledge to inject into the system prompt */
+export function buildKnowledgeSummary(knowledgeDir: string): string | null {
+  const knowledge = loadStructuredKnowledge(knowledgeDir);
+  if (!knowledge || knowledge.endpoints.length === 0) return null;
+  return formatKnowledgeSummary(knowledge);
+}
+
+export function formatKnowledgeSummary(k: StructuredKnowledge): string {
+  const lines: string[] = [];
+
+  lines.push(`## API: ${k.info.title}${k.info.version ? ` (v${k.info.version})` : ''}`);
+  if (k.info.description) lines.push(k.info.description);
+
+  // Servers
+  if (k.servers.length) {
+    lines.push('', '### Base URLs');
+    for (const s of k.servers) {
+      lines.push(`- ${s.url}${s.description ? ` (${s.description})` : ''}`);
+    }
+  }
+
+  // Auth
+  if (k.auth.length) {
+    lines.push('', '### Authentication');
+    for (const a of k.auth) {
+      if (a.type === 'http' && a.scheme === 'bearer') {
+        lines.push(`- **${a.name}**: Bearer token${a.bearerFormat ? ` (${a.bearerFormat})` : ''}`);
+      } else if (a.type === 'apiKey') {
+        lines.push(`- **${a.name}**: API Key in ${a.in} → \`${a.paramName}\``);
+      } else if (a.type === 'oauth2') {
+        lines.push(`- **${a.name}**: OAuth2`);
+      } else {
+        lines.push(`- **${a.name}**: ${a.type}${a.scheme ? ` (${a.scheme})` : ''}`);
+      }
+    }
+  }
+
+  // Endpoints summary
+  lines.push('', '### Available Endpoints');
+  for (const ep of k.endpoints) {
+    const params = ep.parameters.filter(p => p.required).map(p => p.name);
+    const paramStr = params.length ? ` [required: ${params.join(', ')}]` : '';
+    const bodyStr = ep.requestBody ? ' (has body)' : '';
+    const desc = ep.summary ? ` — ${ep.summary}` : '';
+    lines.push(`- \`${ep.method} ${ep.path}\`${desc}${paramStr}${bodyStr}`);
+  }
+
+  return lines.join('\n');
+}

--- a/src/lib/agent/prompts.ts
+++ b/src/lib/agent/prompts.ts
@@ -1,22 +1,34 @@
 export const SYSTEM_PROMPT = `You are Anvil, an AI-powered API testing agent.
 
 ## Your workflow
-1. Read the knowledge base (read_knowledge) to understand the available API endpoints
+1. Review the auto-injected API knowledge below to understand the available endpoints
 2. Plan the test scenario based on the user's natural language description
 3. Execute the tests step by step using the tools provided
 4. Report each test result
 
 ## Tools available
-- **read_knowledge** — Look up API specs, endpoints, schemas from the parsed knowledge base
 - **call_api** — Make HTTP requests. Use {{variableName}} in paths and bodies to reference stored variables
 - **assert_status** — Check the last response's status code
 - **assert_body** — Check values in the last response body using dot-notation paths (e.g. "data.id", "items[0].name")
 - **extract_value** — Save a value from the response for use in later steps
 - **get_variable** — Retrieve a stored variable
+- **read_knowledge** — Look up detailed schema information when you need full request/response body details beyond the injected summary
+- **ask_user** — Ask the user a clarifying question when information is missing or ambiguous
 - **report_result** — Log a test as pass/fail/warn
 
+## API Knowledge
+The API spec has been auto-injected into your context below. You already know the available endpoints, authentication schemes, and base URLs — no need to call read_knowledge for basic endpoint info.
+
+Use **read_knowledge** only when you need:
+- Full request/response body schemas with all field details
+- Detailed enum values, validation rules, or nested object structures
+
+Use **ask_user** when:
+- The spec doesn't contain enough info to proceed (e.g. missing auth credentials, ambiguous endpoints)
+- The user's request is unclear and you need clarification
+- You need specific test data that can't be generated
+
 ## Rules
-- Always start by checking the knowledge base for relevant endpoints
 - Generate realistic test data (names, emails, etc.) — don't use obvious fakes like "test123"
 - Test both happy paths and edge cases when asked
 - Use extract_value to chain requests (e.g. create → get by ID)

--- a/src/lib/parser/knowledge-writer.ts
+++ b/src/lib/parser/knowledge-writer.ts
@@ -1,0 +1,70 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { StructuredKnowledge } from './types';
+
+/** Write structured knowledge as JSON files to the output directory */
+export function writeStructuredKnowledge(knowledge: StructuredKnowledge, outputDir: string): void {
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+
+  // endpoints.json
+  fs.writeFileSync(
+    path.join(outputDir, 'endpoints.json'),
+    JSON.stringify(knowledge.endpoints, null, 2),
+    'utf-8',
+  );
+
+  // auth.json
+  fs.writeFileSync(
+    path.join(outputDir, 'auth.json'),
+    JSON.stringify(knowledge.auth, null, 2),
+    'utf-8',
+  );
+
+  // schemas.json
+  fs.writeFileSync(
+    path.join(outputDir, 'schemas.json'),
+    JSON.stringify(knowledge.schemas, null, 2),
+    'utf-8',
+  );
+
+  // info.json (servers + info)
+  fs.writeFileSync(
+    path.join(outputDir, 'info.json'),
+    JSON.stringify({ info: knowledge.info, servers: knowledge.servers }, null, 2),
+    'utf-8',
+  );
+}
+
+/** Load structured knowledge from JSON files in the knowledge directory */
+export function loadStructuredKnowledge(knowledgeDir: string): StructuredKnowledge | null {
+  try {
+    const endpointsPath = path.join(knowledgeDir, 'endpoints.json');
+    if (!fs.existsSync(endpointsPath)) return null;
+
+    const endpoints = JSON.parse(fs.readFileSync(endpointsPath, 'utf-8'));
+    const auth = safeReadJson(path.join(knowledgeDir, 'auth.json'), []);
+    const schemas = safeReadJson(path.join(knowledgeDir, 'schemas.json'), {});
+    const infoData = safeReadJson(path.join(knowledgeDir, 'info.json'), { info: { title: 'API' }, servers: [] });
+
+    return {
+      endpoints,
+      auth,
+      schemas,
+      servers: infoData.servers || [],
+      info: infoData.info || { title: 'API' },
+    };
+  } catch {
+    return null;
+  }
+}
+
+function safeReadJson(filePath: string, fallback: any): any {
+  try {
+    if (!fs.existsSync(filePath)) return fallback;
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  } catch {
+    return fallback;
+  }
+}

--- a/src/lib/parser/postman.ts
+++ b/src/lib/parser/postman.ts
@@ -1,4 +1,14 @@
 import * as fs from 'fs';
+import {
+  StructuredKnowledge,
+  ParsedEndpoint,
+  ParsedParameter,
+  ParsedRequestBody,
+  ParsedResponse,
+  ParsedSchema,
+  ParsedAuthScheme,
+  ParsedSecurityRequirement,
+} from './types';
 
 interface PostmanCollection {
   info?: { name?: string; description?: string; schema?: string };
@@ -51,6 +61,172 @@ interface PostmanVariable {
   description?: string;
 }
 
+/** Parse a Postman collection into structured knowledge */
+export async function parsePostmanStructured(filePath: string): Promise<StructuredKnowledge> {
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  const collection: PostmanCollection = JSON.parse(raw);
+
+  const info = {
+    title: collection.info?.name || 'Postman Collection',
+    description: collection.info?.description,
+  };
+
+  // Extract base URL from variables
+  const servers: Array<{ url: string; description?: string }> = [];
+  const baseUrlVar = collection.variable?.find(v => v.key === 'baseUrl' || v.key === 'base_url');
+  if (baseUrlVar) {
+    servers.push({ url: baseUrlVar.value, description: baseUrlVar.description });
+  }
+
+  // Auth
+  const auth: ParsedAuthScheme[] = [];
+  if (collection.auth) {
+    auth.push(convertPostmanAuth(collection.auth, 'collection'));
+  }
+
+  // Flatten items into endpoints
+  const endpoints: ParsedEndpoint[] = [];
+  flattenItemsStructured(collection.item || [], endpoints, collection.auth);
+
+  return { endpoints, auth, schemas: {}, servers, info };
+}
+
+function convertPostmanAuth(auth: PostmanAuth, name: string): ParsedAuthScheme {
+  if (auth.type === 'bearer') {
+    return { name, type: 'http', scheme: 'bearer' };
+  }
+  if (auth.type === 'apikey') {
+    const keyEntry = auth.apikey?.find(e => e.key === 'key');
+    const inEntry = auth.apikey?.find(e => e.key === 'in');
+    return {
+      name,
+      type: 'apiKey',
+      paramName: keyEntry?.value,
+      in: inEntry?.value || 'header',
+    };
+  }
+  return { name, type: auth.type || 'unknown' };
+}
+
+function flattenItemsStructured(
+  items: PostmanItem[],
+  endpoints: ParsedEndpoint[],
+  collectionAuth?: PostmanAuth,
+): void {
+  for (const item of items) {
+    if (item.item?.length) {
+      flattenItemsStructured(item.item, endpoints, collectionAuth);
+    } else if (item.request) {
+      endpoints.push(buildPostmanEndpoint(item, collectionAuth));
+    }
+  }
+}
+
+function buildPostmanEndpoint(item: PostmanItem, collectionAuth?: PostmanAuth): ParsedEndpoint {
+  const req = item.request!;
+  const method = (req.method || 'GET').toUpperCase();
+  const url = typeof req.url === 'string' ? req.url : req.url?.raw || buildUrl(req.url);
+
+  // Extract query params
+  const parameters: ParsedParameter[] = [];
+  const queryParams = typeof req.url === 'object' ? req.url?.query?.filter(q => !q.disabled) : undefined;
+  if (queryParams) {
+    for (const q of queryParams) {
+      parameters.push({
+        name: q.key,
+        in: 'query',
+        required: false,
+        description: q.description,
+        schema: { type: 'string' },
+      });
+    }
+  }
+
+  // Request body
+  let requestBody: ParsedRequestBody | undefined;
+  if (req.body?.raw) {
+    let schema: ParsedSchema = { type: 'string' };
+    try {
+      const parsed = JSON.parse(req.body.raw);
+      schema = inferSchemaFromExample(parsed);
+    } catch {
+      // not JSON
+    }
+    requestBody = {
+      required: true,
+      contentType: 'application/json',
+      schema,
+    };
+  }
+
+  // Responses from examples
+  const responses: Record<string, ParsedResponse> = {};
+  if (item.response?.length) {
+    for (const resp of item.response) {
+      const code = String(resp.code || resp.status || '200');
+      const response: ParsedResponse = { description: resp.name || '' };
+      if (resp.body) {
+        try {
+          const parsed = JSON.parse(resp.body);
+          response.contentType = 'application/json';
+          response.schema = inferSchemaFromExample(parsed);
+        } catch {
+          // not JSON
+        }
+      }
+      responses[code] = response;
+    }
+  }
+
+  // Security
+  const security: ParsedSecurityRequirement[] = [];
+  const auth = req.auth || collectionAuth;
+  if (auth?.type) {
+    security.push({ schemeName: auth.type, scopes: [] });
+  }
+
+  return {
+    method,
+    path: url,
+    summary: item.name,
+    description: req.description,
+    tags: [],
+    parameters,
+    requestBody,
+    responses,
+    security,
+  };
+}
+
+function buildUrl(url: any): string {
+  if (!url) return '';
+  const host = Array.isArray(url.host) ? url.host.join('.') : url.host || '';
+  const p = Array.isArray(url.path) ? '/' + url.path.join('/') : '';
+  return `${host}${p}`;
+}
+
+/** Infer a schema from an example value */
+function inferSchemaFromExample(value: unknown): ParsedSchema {
+  if (value === null || value === undefined) return { type: 'any' };
+  if (Array.isArray(value)) {
+    return {
+      type: 'array',
+      items: value.length > 0 ? inferSchemaFromExample(value[0]) : { type: 'any' },
+    };
+  }
+  if (typeof value === 'object') {
+    const props: Record<string, ParsedSchema> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      props[k] = inferSchemaFromExample(v);
+    }
+    return { type: 'object', properties: props };
+  }
+  if (typeof value === 'number') return { type: Number.isInteger(value) ? 'integer' : 'number' };
+  if (typeof value === 'boolean') return { type: 'boolean' };
+  return { type: 'string' };
+}
+
+/** Parse a Postman collection and return markdown (legacy format) */
 export async function parsePostmanCollection(filePath: string): Promise<string> {
   const raw = fs.readFileSync(filePath, 'utf-8');
   const collection: PostmanCollection = JSON.parse(raw);
@@ -76,26 +252,25 @@ export async function parsePostmanCollection(filePath: string): Promise<string> 
 
   // Endpoints
   lines.push('', '## Endpoints');
-  flattenItems(collection.item || [], lines, 0);
+  flattenItemsMd(collection.item || [], lines, 0);
 
   return lines.join('\n');
 }
 
-function flattenItems(items: PostmanItem[], lines: string[], depth: number): void {
+function flattenItemsMd(items: PostmanItem[], lines: string[], depth: number): void {
   for (const item of items) {
     if (item.item?.length) {
-      // Folder
       const hashes = '#'.repeat(Math.min(depth + 3, 6));
       lines.push('', `${hashes} ${item.name || 'Folder'}`, '');
       if (item.description) lines.push(item.description, '');
-      flattenItems(item.item, lines, depth + 1);
+      flattenItemsMd(item.item, lines, depth + 1);
     } else if (item.request) {
-      formatRequest(item, lines);
+      formatRequestMd(item, lines);
     }
   }
 }
 
-function formatRequest(item: PostmanItem, lines: string[]): void {
+function formatRequestMd(item: PostmanItem, lines: string[]): void {
   const req = item.request!;
   const method = req.method || 'GET';
   const url = typeof req.url === 'string' ? req.url : req.url?.raw || buildUrl(req.url);
@@ -104,7 +279,6 @@ function formatRequest(item: PostmanItem, lines: string[]): void {
   if (item.name) lines.push('', `**${item.name}**`);
   if (req.description) lines.push('', req.description);
 
-  // Query params
   const queryParams = typeof req.url === 'object' ? req.url?.query?.filter(q => !q.disabled) : undefined;
   if (queryParams?.length) {
     lines.push('', '**Query Parameters:**', '');
@@ -113,7 +287,6 @@ function formatRequest(item: PostmanItem, lines: string[]): void {
     }
   }
 
-  // Headers
   const headers = req.header?.filter(h => !h.key.toLowerCase().startsWith('content-type'));
   if (headers?.length) {
     lines.push('', '**Headers:**', '');
@@ -122,17 +295,14 @@ function formatRequest(item: PostmanItem, lines: string[]): void {
     }
   }
 
-  // Body
   if (req.body?.raw) {
     lines.push('', '**Request Body:**', '', '```json', tryPrettyJson(req.body.raw), '```');
   }
 
-  // Auth
   if (req.auth) {
     lines.push('', formatAuth(req.auth));
   }
 
-  // Example responses
   if (item.response?.length) {
     lines.push('', '**Example Responses:**', '');
     for (const resp of item.response.slice(0, 3)) {
@@ -144,13 +314,6 @@ function formatRequest(item: PostmanItem, lines: string[]): void {
   }
 
   lines.push('');
-}
-
-function buildUrl(url: any): string {
-  if (!url) return '';
-  const host = Array.isArray(url.host) ? url.host.join('.') : url.host || '';
-  const p = Array.isArray(url.path) ? '/' + url.path.join('/') : '';
-  return `${host}${p}`;
 }
 
 function formatAuth(auth: PostmanAuth): string {

--- a/src/lib/parser/swagger.ts
+++ b/src/lib/parser/swagger.ts
@@ -1,5 +1,16 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import {
+  StructuredKnowledge,
+  ParsedEndpoint,
+  ParsedParameter,
+  ParsedRequestBody,
+  ParsedResponse,
+  ParsedSchema,
+  ParsedAuthScheme,
+  ParsedSecurityRequirement,
+} from './types';
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const SwaggerParser = require('swagger-parser');
 
@@ -10,9 +21,11 @@ interface OpenAPISpec {
   servers?: Array<{ url: string; description?: string }>;
   host?: string;
   basePath?: string;
+  schemes?: string[];
   paths?: Record<string, Record<string, OperationObject>>;
   components?: { schemas?: Record<string, SchemaObject>; securitySchemes?: Record<string, any> };
   securityDefinitions?: Record<string, any>;
+  security?: any[];
 }
 
 interface OperationObject {
@@ -21,7 +34,7 @@ interface OperationObject {
   operationId?: string;
   parameters?: ParameterObject[];
   requestBody?: { description?: string; required?: boolean; content?: Record<string, { schema?: SchemaObject }> };
-  responses?: Record<string, { description?: string; content?: Record<string, { schema?: SchemaObject }> }>;
+  responses?: Record<string, { description?: string; content?: Record<string, { schema?: SchemaObject }>; schema?: SchemaObject }>;
   tags?: string[];
   security?: any[];
 }
@@ -33,6 +46,8 @@ interface ParameterObject {
   description?: string;
   schema?: SchemaObject;
   type?: string;
+  format?: string;
+  enum?: any[];
 }
 
 interface SchemaObject {
@@ -48,74 +63,272 @@ interface SchemaObject {
   allOf?: SchemaObject[];
   oneOf?: SchemaObject[];
   anyOf?: SchemaObject[];
+  default?: any;
+  nullable?: boolean;
+  readOnly?: boolean;
+  writeOnly?: boolean;
+  minimum?: number;
+  maximum?: number;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
 }
 
-export async function parseOpenAPISpec(filePath: string): Promise<string> {
+/** Parse an OpenAPI/Swagger spec into structured knowledge */
+export async function parseOpenAPIStructured(filePath: string): Promise<StructuredKnowledge> {
   const api = (await SwaggerParser.dereference(filePath)) as OpenAPISpec;
-  const lines: string[] = [];
 
-  // Header
-  const title = api.info?.title || path.basename(filePath);
-  lines.push(`# ${title}`);
-  if (api.info?.description) lines.push('', api.info.description);
-  if (api.info?.version) lines.push('', `**Version:** ${api.info.version}`);
+  const info = {
+    title: api.info?.title || path.basename(filePath),
+    version: api.info?.version,
+    description: api.info?.description,
+  };
 
-  // Base URL
+  // Servers
+  const servers: Array<{ url: string; description?: string }> = [];
   if (api.servers?.length) {
-    lines.push('', '## Base URL', '');
     for (const s of api.servers) {
-      lines.push(`- \`${s.url}\`${s.description ? ` — ${s.description}` : ''}`);
+      servers.push({ url: s.url, description: s.description });
     }
   } else if (api.host) {
-    const scheme = (api as any).schemes?.[0] || 'https';
-    lines.push('', '## Base URL', '', `- \`${scheme}://${api.host}${api.basePath || ''}\``);
+    const scheme = api.schemes?.[0] || 'https';
+    servers.push({ url: `${scheme}://${api.host}${api.basePath || ''}` });
   }
 
-  // Auth
-  const secSchemes = api.components?.securitySchemes || api.securityDefinitions;
-  if (secSchemes) {
-    lines.push('', '## Authentication', '');
-    for (const [name, scheme] of Object.entries(secSchemes)) {
-      const s = scheme as any;
-      if (s.type === 'http' || s.type === 'bearer') {
-        lines.push(`- **${name}**: Bearer token in \`Authorization\` header`);
-      } else if (s.type === 'apiKey') {
-        lines.push(`- **${name}**: API key in \`${s.in}\` → \`${s.name}\``);
-      } else if (s.type === 'oauth2') {
-        lines.push(`- **${name}**: OAuth2`);
-      } else {
-        lines.push(`- **${name}**: ${s.type || 'unknown'}`);
-      }
-    }
-  }
+  // Auth schemes
+  const auth = extractAuthSchemes(api.components?.securitySchemes || api.securityDefinitions);
 
-  // Endpoints grouped by tag
-  if (api.paths) {
-    const byTag = new Map<string, string[]>();
-
-    for (const [urlPath, methods] of Object.entries(api.paths)) {
-      for (const [method, op] of Object.entries(methods)) {
-        if (['get', 'post', 'put', 'patch', 'delete', 'head', 'options'].indexOf(method) === -1) continue;
-        const operation = op as OperationObject;
-        const tag = operation.tags?.[0] || 'Default';
-        if (!byTag.has(tag)) byTag.set(tag, []);
-        byTag.get(tag)!.push(formatEndpoint(method, urlPath, operation));
-      }
-    }
-
-    lines.push('', '## Endpoints');
-    for (const [tag, endpoints] of byTag) {
-      lines.push('', `### ${tag}`, '');
-      lines.push(...endpoints);
-    }
-  }
+  // Global security
+  const globalSecurity = extractSecurityRequirements(api.security);
 
   // Schemas
+  const schemas: Record<string, ParsedSchema> = {};
   if (api.components?.schemas) {
-    lines.push('', '## Schemas', '');
     for (const [name, schema] of Object.entries(api.components.schemas)) {
+      schemas[name] = convertSchema(schema);
+    }
+  }
+
+  // Endpoints
+  const endpoints: ParsedEndpoint[] = [];
+  if (api.paths) {
+    const methods = ['get', 'post', 'put', 'patch', 'delete', 'head', 'options'];
+    for (const [urlPath, pathItem] of Object.entries(api.paths)) {
+      for (const [method, op] of Object.entries(pathItem)) {
+        if (!methods.includes(method)) continue;
+        const operation = op as OperationObject;
+        endpoints.push(buildEndpoint(method, urlPath, operation, globalSecurity));
+      }
+    }
+  }
+
+  return { endpoints, auth, schemas, servers, info };
+}
+
+function extractAuthSchemes(secSchemes: Record<string, any> | undefined): ParsedAuthScheme[] {
+  if (!secSchemes) return [];
+  const result: ParsedAuthScheme[] = [];
+  for (const [name, scheme] of Object.entries(secSchemes)) {
+    const s = scheme as any;
+    const auth: ParsedAuthScheme = { name, type: s.type || 'unknown' };
+    if (s.type === 'http') {
+      auth.scheme = s.scheme;
+      auth.bearerFormat = s.bearerFormat;
+    } else if (s.type === 'apiKey') {
+      auth.in = s.in;
+      auth.paramName = s.name;
+    } else if (s.type === 'oauth2' && s.flows) {
+      auth.flows = {};
+      for (const [flowType, flow] of Object.entries(s.flows)) {
+        const f = flow as any;
+        auth.flows[flowType] = {
+          authorizationUrl: f.authorizationUrl,
+          tokenUrl: f.tokenUrl,
+          scopes: f.scopes,
+        };
+      }
+    }
+    auth.description = s.description;
+    result.push(auth);
+  }
+  return result;
+}
+
+function extractSecurityRequirements(security: any[] | undefined): ParsedSecurityRequirement[] {
+  if (!security) return [];
+  const result: ParsedSecurityRequirement[] = [];
+  for (const req of security) {
+    for (const [schemeName, scopes] of Object.entries(req)) {
+      result.push({ schemeName, scopes: (scopes as string[]) || [] });
+    }
+  }
+  return result;
+}
+
+function buildEndpoint(
+  method: string,
+  urlPath: string,
+  op: OperationObject,
+  globalSecurity: ParsedSecurityRequirement[],
+): ParsedEndpoint {
+  const parameters: ParsedParameter[] = [];
+  for (const p of (op.parameters || []).filter(p => p.in !== 'body')) {
+    parameters.push({
+      name: p.name,
+      in: p.in as ParsedParameter['in'],
+      required: p.required || false,
+      description: p.description,
+      schema: convertSchema(p.schema || { type: p.type || 'string', format: p.format, enum: p.enum }),
+    });
+  }
+
+  let requestBody: ParsedRequestBody | undefined;
+  if (op.requestBody?.content) {
+    const [contentType, media] = Object.entries(op.requestBody.content)[0] || [];
+    if (contentType && media?.schema) {
+      requestBody = {
+        description: op.requestBody.description,
+        required: op.requestBody.required || false,
+        contentType,
+        schema: convertSchema(media.schema),
+      };
+    }
+  }
+  // Swagger 2.0 body param
+  const bodyParam = op.parameters?.find(p => p.in === 'body');
+  if (!requestBody && bodyParam?.schema) {
+    requestBody = {
+      required: bodyParam.required || false,
+      contentType: 'application/json',
+      schema: convertSchema(bodyParam.schema as SchemaObject),
+    };
+  }
+
+  const responses: Record<string, ParsedResponse> = {};
+  if (op.responses) {
+    for (const [code, resp] of Object.entries(op.responses)) {
+      const r = resp as any;
+      const response: ParsedResponse = { description: r.description || '' };
+      const jsonSchema = r.content?.['application/json']?.schema || r.schema;
+      if (jsonSchema) {
+        response.contentType = 'application/json';
+        response.schema = convertSchema(jsonSchema);
+      }
+      responses[code] = response;
+    }
+  }
+
+  const security = op.security
+    ? extractSecurityRequirements(op.security)
+    : globalSecurity;
+
+  return {
+    method: method.toUpperCase(),
+    path: urlPath,
+    summary: op.summary,
+    description: op.description,
+    operationId: op.operationId,
+    tags: op.tags || [],
+    parameters,
+    requestBody,
+    responses,
+    security,
+  };
+}
+
+function convertSchema(schema: SchemaObject | undefined): ParsedSchema {
+  if (!schema) return { type: 'any' };
+  const result: ParsedSchema = {};
+  if (schema.type) result.type = schema.type;
+  if (schema.format) result.format = schema.format;
+  if (schema.description) result.description = schema.description;
+  if (schema.required) result.required = schema.required;
+  if (schema.enum) result.enum = schema.enum;
+  if (schema.example !== undefined) result.example = schema.example;
+  if (schema.default !== undefined) result.default = schema.default;
+  if (schema.nullable) result.nullable = schema.nullable;
+  if (schema.readOnly) result.readOnly = schema.readOnly;
+  if (schema.writeOnly) result.writeOnly = schema.writeOnly;
+  if (schema.minimum !== undefined) result.minimum = schema.minimum;
+  if (schema.maximum !== undefined) result.maximum = schema.maximum;
+  if (schema.minLength !== undefined) result.minLength = schema.minLength;
+  if (schema.maxLength !== undefined) result.maxLength = schema.maxLength;
+  if (schema.pattern) result.pattern = schema.pattern;
+  if (schema.properties) {
+    result.properties = {};
+    for (const [name, prop] of Object.entries(schema.properties)) {
+      result.properties[name] = convertSchema(prop);
+    }
+  }
+  if (schema.items) result.items = convertSchema(schema.items);
+  if (schema.allOf) result.allOf = schema.allOf.map(s => convertSchema(s));
+  if (schema.oneOf) result.oneOf = schema.oneOf.map(s => convertSchema(s));
+  if (schema.anyOf) result.anyOf = schema.anyOf.map(s => convertSchema(s));
+  // Infer type if has properties but no explicit type
+  if (!result.type && result.properties) result.type = 'object';
+  if (!result.type && result.items) result.type = 'array';
+  return result;
+}
+
+/** Parse OpenAPI spec and return markdown (legacy format) */
+export async function parseOpenAPISpec(filePath: string): Promise<string> {
+  const knowledge = await parseOpenAPIStructured(filePath);
+  return knowledgeToMarkdown(knowledge);
+}
+
+/** Convert structured knowledge to markdown */
+export function knowledgeToMarkdown(k: StructuredKnowledge): string {
+  const lines: string[] = [];
+
+  lines.push(`# ${k.info.title}`);
+  if (k.info.description) lines.push('', k.info.description);
+  if (k.info.version) lines.push('', `**Version:** ${k.info.version}`);
+
+  if (k.servers.length) {
+    lines.push('', '## Base URL', '');
+    for (const s of k.servers) {
+      lines.push(`- \`${s.url}\`${s.description ? ` — ${s.description}` : ''}`);
+    }
+  }
+
+  if (k.auth.length) {
+    lines.push('', '## Authentication', '');
+    for (const a of k.auth) {
+      if (a.type === 'http' && a.scheme === 'bearer') {
+        lines.push(`- **${a.name}**: Bearer token in \`Authorization\` header`);
+      } else if (a.type === 'http') {
+        lines.push(`- **${a.name}**: HTTP ${a.scheme}`);
+      } else if (a.type === 'apiKey') {
+        lines.push(`- **${a.name}**: API key in \`${a.in}\` → \`${a.paramName}\``);
+      } else if (a.type === 'oauth2') {
+        lines.push(`- **${a.name}**: OAuth2`);
+      } else {
+        lines.push(`- **${a.name}**: ${a.type}`);
+      }
+    }
+  }
+
+  // Group endpoints by tag
+  const byTag = new Map<string, ParsedEndpoint[]>();
+  for (const ep of k.endpoints) {
+    const tag = ep.tags[0] || 'Default';
+    if (!byTag.has(tag)) byTag.set(tag, []);
+    byTag.get(tag)!.push(ep);
+  }
+
+  lines.push('', '## Endpoints');
+  for (const [tag, endpoints] of byTag) {
+    lines.push('', `### ${tag}`, '');
+    for (const ep of endpoints) {
+      lines.push(formatEndpointMd(ep));
+    }
+  }
+
+  if (Object.keys(k.schemas).length) {
+    lines.push('', '## Schemas', '');
+    for (const [name, schema] of Object.entries(k.schemas)) {
       lines.push(`### ${name}`, '');
-      lines.push(formatSchema(schema, 0));
+      lines.push(formatSchemaMd(schema, 0));
       lines.push('');
     }
   }
@@ -123,47 +336,33 @@ export async function parseOpenAPISpec(filePath: string): Promise<string> {
   return lines.join('\n');
 }
 
-function formatEndpoint(method: string, urlPath: string, op: OperationObject): string {
+function formatEndpointMd(ep: ParsedEndpoint): string {
   const lines: string[] = [];
-  lines.push(`#### \`${method.toUpperCase()} ${urlPath}\``);
-  if (op.summary) lines.push('', op.summary);
-  if (op.description && op.description !== op.summary) lines.push('', op.description);
+  lines.push(`#### \`${ep.method} ${ep.path}\``);
+  if (ep.summary) lines.push('', ep.summary);
+  if (ep.description && ep.description !== ep.summary) lines.push('', ep.description);
 
-  // Parameters
-  const params = op.parameters?.filter(p => p.in !== 'body');
-  if (params?.length) {
+  const params = ep.parameters.filter(p => (p.in as string) !== 'body');
+  if (params.length) {
     lines.push('', '**Parameters:**', '');
     for (const p of params) {
       const req = p.required ? '*(required)*' : '*(optional)*';
-      const type = p.schema?.type || p.type || 'string';
+      const type = p.schema.type || 'string';
       lines.push(`- \`${p.name}\` (${p.in}, ${type}) ${req}${p.description ? ' — ' + p.description : ''}`);
     }
   }
 
-  // Request body
-  if (op.requestBody?.content) {
-    const jsonContent = op.requestBody.content['application/json'];
-    if (jsonContent?.schema) {
-      lines.push('', '**Request Body** (application/json):', '');
-      lines.push(formatSchema(jsonContent.schema, 0));
-    }
-  }
-  // Swagger 2.0 body param
-  const bodyParam = op.parameters?.find(p => p.in === 'body');
-  if (bodyParam?.schema) {
-    lines.push('', '**Request Body:**', '');
-    lines.push(formatSchema(bodyParam.schema as SchemaObject, 0));
+  if (ep.requestBody) {
+    lines.push('', `**Request Body** (${ep.requestBody.contentType}):`, '');
+    lines.push(formatSchemaMd(ep.requestBody.schema, 0));
   }
 
-  // Responses
-  if (op.responses) {
+  if (Object.keys(ep.responses).length) {
     lines.push('', '**Responses:**', '');
-    for (const [code, resp] of Object.entries(op.responses)) {
-      const r = resp as any;
-      lines.push(`- \`${code}\`: ${r.description || ''}`);
-      const jsonResp = r.content?.['application/json']?.schema || r.schema;
-      if (jsonResp) {
-        lines.push(formatSchema(jsonResp, 1));
+    for (const [code, resp] of Object.entries(ep.responses)) {
+      lines.push(`- \`${code}\`: ${resp.description}`);
+      if (resp.schema) {
+        lines.push(formatSchemaMd(resp.schema, 1));
       }
     }
   }
@@ -172,7 +371,7 @@ function formatEndpoint(method: string, urlPath: string, op: OperationObject): s
   return lines.join('\n');
 }
 
-function formatSchema(schema: SchemaObject, indent: number): string {
+function formatSchemaMd(schema: ParsedSchema, indent: number): string {
   const pad = '  '.repeat(indent);
   if (!schema) return `${pad}*(unknown)*`;
 
@@ -185,14 +384,14 @@ function formatSchema(schema: SchemaObject, indent: number): string {
       const enumStr = prop.enum ? ` — enum: [${prop.enum.join(', ')}]` : '';
       const desc = prop.description ? ` — ${prop.description}` : '';
       lines.push(`${pad}- \`${name}\` (${type})${req}${enumStr}${desc}`);
-      if (prop.properties) lines.push(formatSchema(prop, indent + 1));
-      if (prop.items?.properties) lines.push(formatSchema(prop.items, indent + 1));
+      if (prop.properties) lines.push(formatSchemaMd(prop, indent + 1));
+      if (prop.items?.properties) lines.push(formatSchemaMd(prop.items, indent + 1));
     }
     return lines.join('\n');
   }
 
   if (schema.type === 'array' && schema.items) {
-    return `${pad}Array of:\n${formatSchema(schema.items, indent + 1)}`;
+    return `${pad}Array of:\n${formatSchemaMd(schema.items, indent + 1)}`;
   }
 
   return `${pad}Type: \`${schema.type || 'any'}\`${schema.format ? ` (${schema.format})` : ''}${schema.description ? ' — ' + schema.description : ''}`;

--- a/src/lib/parser/types.ts
+++ b/src/lib/parser/types.ts
@@ -1,0 +1,82 @@
+/** Structured knowledge types for parsed API specs */
+
+export interface ParsedEndpoint {
+  method: string;
+  path: string;
+  summary?: string;
+  description?: string;
+  operationId?: string;
+  tags: string[];
+  parameters: ParsedParameter[];
+  requestBody?: ParsedRequestBody;
+  responses: Record<string, ParsedResponse>;
+  security: ParsedSecurityRequirement[];
+}
+
+export interface ParsedParameter {
+  name: string;
+  in: 'query' | 'path' | 'header' | 'cookie';
+  required: boolean;
+  description?: string;
+  schema: ParsedSchema;
+}
+
+export interface ParsedRequestBody {
+  description?: string;
+  required: boolean;
+  contentType: string;
+  schema: ParsedSchema;
+}
+
+export interface ParsedResponse {
+  description: string;
+  contentType?: string;
+  schema?: ParsedSchema;
+}
+
+export interface ParsedSchema {
+  type?: string;
+  format?: string;
+  description?: string;
+  required?: string[];
+  properties?: Record<string, ParsedSchema>;
+  items?: ParsedSchema;
+  enum?: unknown[];
+  example?: unknown;
+  default?: unknown;
+  allOf?: ParsedSchema[];
+  oneOf?: ParsedSchema[];
+  anyOf?: ParsedSchema[];
+  nullable?: boolean;
+  readOnly?: boolean;
+  writeOnly?: boolean;
+  minimum?: number;
+  maximum?: number;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+}
+
+export interface ParsedAuthScheme {
+  name: string;
+  type: 'http' | 'apiKey' | 'oauth2' | 'openIdConnect' | string;
+  scheme?: string; // e.g. 'bearer'
+  bearerFormat?: string;
+  in?: string; // for apiKey
+  paramName?: string; // for apiKey
+  description?: string;
+  flows?: Record<string, { authorizationUrl?: string; tokenUrl?: string; scopes?: Record<string, string> }>;
+}
+
+export interface ParsedSecurityRequirement {
+  schemeName: string;
+  scopes: string[];
+}
+
+export interface StructuredKnowledge {
+  endpoints: ParsedEndpoint[];
+  auth: ParsedAuthScheme[];
+  schemas: Record<string, ParsedSchema>;
+  servers: Array<{ url: string; description?: string }>;
+  info: { title: string; version?: string; description?: string };
+}

--- a/src/lib/tools/definitions.ts
+++ b/src/lib/tools/definitions.ts
@@ -65,13 +65,24 @@ export const TOOLS: ToolDefinition[] = [
   },
   {
     name: 'read_knowledge',
-    description: 'Read the API knowledge base (parsed specs) to understand available endpoints, request/response schemas, and authentication requirements',
+    description: 'Look up detailed API schema information from the knowledge base. Use for deep schema lookups when you need full request/response body details beyond what is in the injected summary.',
     parameters: {
       type: 'object',
       properties: {
-        query: { type: 'string', description: 'What to look for (e.g. "user endpoints", "authentication", "create order")' },
+        query: { type: 'string', description: 'What to look for (e.g. "user endpoints", "authentication", "create order schema")' },
       },
       required: ['query'],
+    },
+  },
+  {
+    name: 'ask_user',
+    description: 'Ask the user a clarifying question when API spec info is insufficient or ambiguous. Wait for their response before proceeding.',
+    parameters: {
+      type: 'object',
+      properties: {
+        question: { type: 'string', description: 'The question to ask the user' },
+      },
+      required: ['question'],
     },
   },
   {

--- a/src/lib/tools/handlers.ts
+++ b/src/lib/tools/handlers.ts
@@ -2,6 +2,7 @@ import { executeRequest, ExecutionResult } from '../executor/http';
 import { StepEntry, StepRequest, StepCallback } from '../step-log';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as readline from 'readline';
 
 export interface ToolContext {
   baseUrl: string;
@@ -40,6 +41,8 @@ export async function handleToolCall(
       return getVariable(args, ctx);
     case 'read_knowledge':
       return readKnowledge(args, ctx);
+    case 'ask_user':
+      return askUser(args, ctx);
     case 'report_result':
       return reportResult(args, ctx);
     default:
@@ -237,12 +240,26 @@ async function readKnowledge(args: Record<string, unknown>, ctx: ToolContext) {
   const query = (args.query as string).toLowerCase();
 
   try {
-    const files = fs.readdirSync(ctx.knowledgeDir).filter(f => f.endsWith('.md'));
-    if (files.length === 0) return { message: 'Knowledge base is empty. No API specs have been imported yet.' };
+    const allFiles = fs.readdirSync(ctx.knowledgeDir);
+    const mdFiles = allFiles.filter(f => f.endsWith('.md'));
+    const jsonFiles = allFiles.filter(f => f.endsWith('.json'));
 
-    // Simple keyword search across knowledge files
+    if (mdFiles.length === 0 && jsonFiles.length === 0) {
+      return { message: 'Knowledge base is empty. No API specs have been imported yet.' };
+    }
+
     const results: { file: string; content: string }[] = [];
-    for (const file of files) {
+
+    // Search structured JSON files first for detailed schema lookups
+    for (const file of jsonFiles) {
+      const content = fs.readFileSync(path.join(ctx.knowledgeDir, file), 'utf-8');
+      if (content.toLowerCase().includes(query) || file.toLowerCase().includes(query)) {
+        results.push({ file, content: content.slice(0, 5000) });
+      }
+    }
+
+    // Also search markdown files
+    for (const file of mdFiles) {
       const content = fs.readFileSync(path.join(ctx.knowledgeDir, file), 'utf-8');
       if (content.toLowerCase().includes(query) || file.toLowerCase().includes(query)) {
         results.push({ file, content: content.slice(0, 3000) });
@@ -250,10 +267,9 @@ async function readKnowledge(args: Record<string, unknown>, ctx: ToolContext) {
     }
 
     if (results.length === 0) {
-      // Return all files as fallback
       return {
         message: `No exact match for "${query}". Available knowledge files:`,
-        files: files,
+        files: [...jsonFiles, ...mdFiles],
         hint: 'Try reading with a broader query, or use a filename.',
       };
     }
@@ -262,6 +278,31 @@ async function readKnowledge(args: Record<string, unknown>, ctx: ToolContext) {
   } catch {
     return { error: 'Failed to read knowledge directory' };
   }
+}
+
+async function askUser(args: Record<string, unknown>, ctx: ToolContext) {
+  const question = args.question as string;
+
+  const step: StepEntry = {
+    stepNumber: ++ctx.stepCount,
+    toolName: 'ask_user',
+    timestamp: Date.now(),
+  };
+  ctx.steps.push(step);
+  ctx.onStep?.(step);
+
+  // Prompt via stdin
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise<{ answer: string }>((resolve) => {
+    rl.question(`\n🤖 Agent asks: ${question}\n> `, (answer) => {
+      rl.close();
+      resolve({ answer: answer.trim() });
+    });
+  });
 }
 
 function reportResult(args: Record<string, unknown>, ctx: ToolContext) {

--- a/tests/parser-structured.test.ts
+++ b/tests/parser-structured.test.ts
@@ -1,0 +1,320 @@
+import { parseOpenAPIStructured } from '../src/lib/parser/swagger';
+import { parsePostmanStructured } from '../src/lib/parser/postman';
+import { writeStructuredKnowledge, loadStructuredKnowledge } from '../src/lib/parser/knowledge-writer';
+import { buildKnowledgeSummary } from '../src/lib/agent/knowledge-injector';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+const tmpDir = path.join(os.tmpdir(), 'anvil-structured-test');
+
+beforeAll(() => fs.mkdirSync(tmpDir, { recursive: true }));
+afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+describe('OpenAPI structured parser', () => {
+  const spec = {
+    openapi: '3.0.0',
+    info: { title: 'Pet Store', version: '1.0.0', description: 'A sample pet store' },
+    servers: [{ url: 'https://api.petstore.io/v1', description: 'Production' }],
+    components: {
+      securitySchemes: {
+        bearerAuth: { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
+        apiKey: { type: 'apiKey', in: 'header', name: 'X-API-Key' },
+      },
+      schemas: {
+        Pet: {
+          type: 'object',
+          required: ['name'],
+          properties: {
+            id: { type: 'integer', format: 'int64', readOnly: true },
+            name: { type: 'string', description: 'Pet name', minLength: 1, maxLength: 100 },
+            status: { type: 'string', enum: ['available', 'pending', 'sold'], default: 'available' },
+            tags: { type: 'array', items: { type: 'string' } },
+          },
+        },
+      },
+    },
+    security: [{ bearerAuth: [] }],
+    paths: {
+      '/pets': {
+        get: {
+          summary: 'List all pets',
+          operationId: 'listPets',
+          tags: ['Pets'],
+          parameters: [
+            { name: 'limit', in: 'query', required: false, schema: { type: 'integer' }, description: 'Max items' },
+          ],
+          responses: {
+            '200': {
+              description: 'A list of pets',
+              content: { 'application/json': { schema: { type: 'array', items: { $ref: '#/components/schemas/Pet' } } } },
+            },
+          },
+        },
+        post: {
+          summary: 'Create a pet',
+          operationId: 'createPet',
+          tags: ['Pets'],
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/Pet' },
+              },
+            },
+          },
+          responses: { '201': { description: 'Created' } },
+          security: [{ bearerAuth: [], apiKey: [] }],
+        },
+      },
+      '/pets/{petId}': {
+        get: {
+          summary: 'Get a pet by ID',
+          tags: ['Pets'],
+          parameters: [{ name: 'petId', in: 'path', required: true, schema: { type: 'string' } }],
+          responses: {
+            '200': { description: 'A pet', content: { 'application/json': { schema: { $ref: '#/components/schemas/Pet' } } } },
+            '404': { description: 'Not found' },
+          },
+        },
+      },
+    },
+  };
+
+  let specFile: string;
+
+  beforeAll(() => {
+    specFile = path.join(tmpDir, 'petstore-structured.json');
+    fs.writeFileSync(specFile, JSON.stringify(spec));
+  });
+
+  it('resolves $ref references fully', async () => {
+    const k = await parseOpenAPIStructured(specFile);
+    // The POST /pets requestBody should have resolved Pet schema properties
+    const createPet = k.endpoints.find(e => e.method === 'POST' && e.path === '/pets');
+    expect(createPet).toBeDefined();
+    expect(createPet!.requestBody).toBeDefined();
+    expect(createPet!.requestBody!.schema.properties).toBeDefined();
+    expect(createPet!.requestBody!.schema.properties!.name).toBeDefined();
+    expect(createPet!.requestBody!.schema.properties!.name.type).toBe('string');
+  });
+
+  it('extracts auth schemes', async () => {
+    const k = await parseOpenAPIStructured(specFile);
+    expect(k.auth).toHaveLength(2);
+    const bearer = k.auth.find(a => a.name === 'bearerAuth');
+    expect(bearer).toBeDefined();
+    expect(bearer!.type).toBe('http');
+    expect(bearer!.scheme).toBe('bearer');
+    expect(bearer!.bearerFormat).toBe('JWT');
+
+    const apiKey = k.auth.find(a => a.name === 'apiKey');
+    expect(apiKey).toBeDefined();
+    expect(apiKey!.type).toBe('apiKey');
+    expect(apiKey!.in).toBe('header');
+    expect(apiKey!.paramName).toBe('X-API-Key');
+  });
+
+  it('parses full request schemas with required, types, enums', async () => {
+    const k = await parseOpenAPIStructured(specFile);
+    const petSchema = k.schemas['Pet'];
+    expect(petSchema).toBeDefined();
+    expect(petSchema.required).toContain('name');
+    expect(petSchema.properties!.status.enum).toEqual(['available', 'pending', 'sold']);
+    expect(petSchema.properties!.status.default).toBe('available');
+    expect(petSchema.properties!.id.format).toBe('int64');
+    expect(petSchema.properties!.id.readOnly).toBe(true);
+    expect(petSchema.properties!.name.minLength).toBe(1);
+    expect(petSchema.properties!.name.maxLength).toBe(100);
+    expect(petSchema.properties!.tags.type).toBe('array');
+    expect(petSchema.properties!.tags.items!.type).toBe('string');
+  });
+
+  it('parses response schemas per status code', async () => {
+    const k = await parseOpenAPIStructured(specFile);
+    const getPet = k.endpoints.find(e => e.method === 'GET' && e.path === '/pets/{petId}');
+    expect(getPet).toBeDefined();
+    expect(getPet!.responses['200']).toBeDefined();
+    expect(getPet!.responses['200'].schema).toBeDefined();
+    expect(getPet!.responses['200'].schema!.properties!.name).toBeDefined();
+    expect(getPet!.responses['404']).toBeDefined();
+    expect(getPet!.responses['404'].description).toBe('Not found');
+  });
+
+  it('extracts base URL and server info', async () => {
+    const k = await parseOpenAPIStructured(specFile);
+    expect(k.servers).toHaveLength(1);
+    expect(k.servers[0].url).toBe('https://api.petstore.io/v1');
+    expect(k.servers[0].description).toBe('Production');
+  });
+
+  it('extracts security requirements per endpoint', async () => {
+    const k = await parseOpenAPIStructured(specFile);
+    // GET /pets inherits global security
+    const listPets = k.endpoints.find(e => e.method === 'GET' && e.path === '/pets');
+    expect(listPets!.security).toHaveLength(1);
+    expect(listPets!.security[0].schemeName).toBe('bearerAuth');
+
+    // POST /pets has its own security
+    const createPet = k.endpoints.find(e => e.method === 'POST' && e.path === '/pets');
+    expect(createPet!.security).toHaveLength(2);
+  });
+
+  it('extracts parameters with full details', async () => {
+    const k = await parseOpenAPIStructured(specFile);
+    const listPets = k.endpoints.find(e => e.method === 'GET' && e.path === '/pets');
+    expect(listPets!.parameters).toHaveLength(1);
+    expect(listPets!.parameters[0].name).toBe('limit');
+    expect(listPets!.parameters[0].in).toBe('query');
+    expect(listPets!.parameters[0].required).toBe(false);
+    expect(listPets!.parameters[0].schema.type).toBe('integer');
+  });
+});
+
+describe('Swagger 2.0 structured parser', () => {
+  it('parses Swagger 2.0 with body params and securityDefinitions', async () => {
+    const spec = {
+      swagger: '2.0',
+      info: { title: 'Legacy API', version: '2.0' },
+      host: 'api.legacy.com',
+      basePath: '/v2',
+      schemes: ['https'],
+      securityDefinitions: {
+        api_key: { type: 'apiKey', name: 'api_key', in: 'header' },
+      },
+      paths: {
+        '/users': {
+          get: { summary: 'List users', responses: { '200': { description: 'OK' } } },
+          post: {
+            summary: 'Create user',
+            parameters: [
+              {
+                name: 'body',
+                in: 'body',
+                required: true,
+                schema: {
+                  type: 'object',
+                  required: ['name'],
+                  properties: { name: { type: 'string' }, email: { type: 'string', format: 'email' } },
+                },
+              },
+            ],
+            responses: { '201': { description: 'Created' } },
+          },
+        },
+      },
+    };
+
+    const file = path.join(tmpDir, 'swagger2.json');
+    fs.writeFileSync(file, JSON.stringify(spec));
+    const k = await parseOpenAPIStructured(file);
+
+    expect(k.servers[0].url).toBe('https://api.legacy.com/v2');
+    expect(k.auth).toHaveLength(1);
+    expect(k.auth[0].type).toBe('apiKey');
+
+    const createUser = k.endpoints.find(e => e.method === 'POST');
+    expect(createUser!.requestBody).toBeDefined();
+    expect(createUser!.requestBody!.schema.required).toContain('name');
+    expect(createUser!.requestBody!.schema.properties!.email.format).toBe('email');
+  });
+});
+
+describe('Postman structured parser', () => {
+  it('parses a Postman collection into structured format', async () => {
+    const collection = {
+      info: { name: 'My API', description: 'Test collection', schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json' },
+      variable: [{ key: 'baseUrl', value: 'https://api.example.com' }],
+      auth: { type: 'bearer', bearer: [{ key: 'token', value: '{{token}}' }] },
+      item: [
+        {
+          name: 'Users',
+          item: [
+            {
+              name: 'Get Users',
+              request: {
+                method: 'GET',
+                url: { raw: '{{baseUrl}}/users', query: [{ key: 'page', value: '1', description: 'Page number' }] },
+              },
+              response: [{ name: 'Success', code: 200, body: '{"users": []}' }],
+            },
+            {
+              name: 'Create User',
+              request: {
+                method: 'POST',
+                url: '{{baseUrl}}/users',
+                body: { mode: 'raw', raw: '{"name": "John", "email": "john@test.com"}' },
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const file = path.join(tmpDir, 'postman-structured.json');
+    fs.writeFileSync(file, JSON.stringify(collection));
+    const k = await parsePostmanStructured(file);
+
+    expect(k.info.title).toBe('My API');
+    expect(k.servers).toHaveLength(1);
+    expect(k.servers[0].url).toBe('https://api.example.com');
+    expect(k.auth).toHaveLength(1);
+    expect(k.auth[0].scheme).toBe('bearer');
+    expect(k.endpoints).toHaveLength(2);
+
+    const getUsers = k.endpoints.find(e => e.method === 'GET');
+    expect(getUsers!.parameters).toHaveLength(1);
+    expect(getUsers!.parameters[0].name).toBe('page');
+    expect(getUsers!.responses['200']).toBeDefined();
+
+    const createUser = k.endpoints.find(e => e.method === 'POST');
+    expect(createUser!.requestBody).toBeDefined();
+    expect(createUser!.requestBody!.schema.properties!.name.type).toBe('string');
+  });
+});
+
+describe('Knowledge writer/loader', () => {
+  it('writes and loads structured knowledge', async () => {
+    const specFile = path.join(tmpDir, 'petstore-structured.json');
+    const k = await parseOpenAPIStructured(specFile);
+    const outDir = path.join(tmpDir, 'knowledge-out');
+
+    writeStructuredKnowledge(k, outDir);
+
+    expect(fs.existsSync(path.join(outDir, 'endpoints.json'))).toBe(true);
+    expect(fs.existsSync(path.join(outDir, 'auth.json'))).toBe(true);
+    expect(fs.existsSync(path.join(outDir, 'schemas.json'))).toBe(true);
+    expect(fs.existsSync(path.join(outDir, 'info.json'))).toBe(true);
+
+    const loaded = loadStructuredKnowledge(outDir);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.endpoints).toHaveLength(k.endpoints.length);
+    expect(loaded!.auth).toHaveLength(k.auth.length);
+    expect(loaded!.servers).toHaveLength(k.servers.length);
+  });
+});
+
+describe('Knowledge injector', () => {
+  it('builds a summary from structured knowledge', async () => {
+    const specFile = path.join(tmpDir, 'petstore-structured.json');
+    const k = await parseOpenAPIStructured(specFile);
+    const outDir = path.join(tmpDir, 'knowledge-inject');
+    writeStructuredKnowledge(k, outDir);
+
+    const summary = buildKnowledgeSummary(outDir);
+    expect(summary).not.toBeNull();
+    expect(summary).toContain('Pet Store');
+    expect(summary).toContain('https://api.petstore.io/v1');
+    expect(summary).toContain('Bearer token');
+    expect(summary).toContain('GET /pets');
+    expect(summary).toContain('POST /pets');
+    expect(summary).toContain('GET /pets/{petId}');
+  });
+
+  it('returns null for empty knowledge dir', () => {
+    const emptyDir = path.join(tmpDir, 'empty-knowledge');
+    fs.mkdirSync(emptyDir, { recursive: true });
+    const summary = buildKnowledgeSummary(emptyDir);
+    expect(summary).toBeNull();
+  });
+});


### PR DESCRIPTION
## US-4: Smart API Spec Understanding

### Changes

**A. Enhanced Parser** — Upgraded both OpenAPI and Postman parsers to:
- Resolve all `$ref` references fully (via swagger-parser dereference)
- Extract auth schemes (Bearer, API key, OAuth2)
- Parse full request schemas (required fields, types, enums, examples, constraints)
- Parse full response schemas per status code
- Extract base URL and server info

**B. Rich Knowledge Format** — Structured JSON output alongside markdown:
- `endpoints.json` — endpoints with method, path, params, request/response schemas, auth
- `auth.json` — authentication schemes
- `schemas.json` — shared schema definitions
- `info.json` — API info and server URLs

**C. Auto-inject Specs into Agent** — On `run()`, the agent automatically loads structured knowledge and injects an API summary into the system prompt. No need to call `read_knowledge` for basic endpoint info.

**D. URL Import** — `anvil import https://api.example.com/openapi.json` with auto-detection of OpenAPI JSON/YAML and Postman collection formats.

**E. Clarification Tool (`ask_user`)** — New tool allowing the agent to ask the user questions via stdin when spec info is insufficient.

**F. Updated System Prompt** — Reflects auto-injected knowledge, instructs use of `ask_user` for missing info, keeps `read_knowledge` for deep schema lookups.

### Tests
- 31 tests passing (including new structured parser tests covering $ref resolution, auth extraction, schema parsing, knowledge writing/loading, and knowledge injection)