### PR TITLE
fix: improve error handling to surface proper error messages

### DIFF
--- a/src/cli/commands/test.ts
+++ b/src/cli/commands/test.ts
@@ -77,7 +77,8 @@ export async function runTest(args: string[]): Promise<void> {
       console.log(`\n💬 ${result.message}`);
     }
   } catch (err: any) {
-    console.error(`\n❌ Error: ${err.message}`);
+    const { extractErrorMessage } = await import('../../lib/utils/error');
+    console.error(`\n❌ Error: ${extractErrorMessage(err)}`);
     process.exit(1);
   }
 }

--- a/src/cli/commands/test.ts
+++ b/src/cli/commands/test.ts
@@ -3,6 +3,7 @@ import { createAdapter } from '../../lib/adapters/factory';
 import { AgentCore } from '../../lib/agent/core';
 import { formatStep, FormatOptions } from '../format-step';
 import { loadCredentials, getResolvedApiKey } from '../../lib/credentials';
+import { extractErrorMessage } from '../../lib/utils/error';
 
 export async function runTest(args: string[]): Promise<void> {
   const verbose = args.includes('--verbose') || args.includes('-v');
@@ -77,7 +78,6 @@ export async function runTest(args: string[]): Promise<void> {
       console.log(`\n💬 ${result.message}`);
     }
   } catch (err: any) {
-    const { extractErrorMessage } = await import('../../lib/utils/error');
     console.error(`\n❌ Error: ${extractErrorMessage(err)}`);
     process.exit(1);
   }

--- a/src/lib/adapters/claude.ts
+++ b/src/lib/adapters/claude.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { LLMAdapter, LLMMessage, LLMResponse, ToolDefinition, ToolCall } from './interface';
+import { extractErrorMessage } from '../utils/error';
 
 export class ClaudeAdapter implements LLMAdapter {
   private apiKey: string;
@@ -34,13 +35,18 @@ export class ClaudeAdapter implements LLMAdapter {
       }));
     }
 
-    const res = await axios.post('https://api.anthropic.com/v1/messages', body, {
-      headers: {
-        'x-api-key': this.apiKey,
-        'anthropic-version': '2023-06-01',
-        'Content-Type': 'application/json',
-      },
-    });
+    let res;
+    try {
+      res = await axios.post('https://api.anthropic.com/v1/messages', body, {
+        headers: {
+          'x-api-key': this.apiKey,
+          'anthropic-version': '2023-06-01',
+          'Content-Type': 'application/json',
+        },
+      });
+    } catch (err: any) {
+      throw new Error(`Claude API error: ${extractErrorMessage(err)}`);
+    }
 
     const content = res.data.content;
     let text = '';

--- a/src/lib/adapters/openai.ts
+++ b/src/lib/adapters/openai.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { LLMAdapter, LLMMessage, LLMResponse, ToolDefinition, ToolCall } from './interface';
+import { extractErrorMessage } from '../utils/error';
 
 export class OpenAIAdapter implements LLMAdapter {
   private apiKey: string;
@@ -27,9 +28,14 @@ export class OpenAIAdapter implements LLMAdapter {
       }));
     }
 
-    const res = await axios.post('https://api.openai.com/v1/chat/completions', body, {
-      headers: { Authorization: `Bearer ${this.apiKey}`, 'Content-Type': 'application/json' },
-    });
+    let res;
+    try {
+      res = await axios.post('https://api.openai.com/v1/chat/completions', body, {
+        headers: { Authorization: `Bearer ${this.apiKey}`, 'Content-Type': 'application/json' },
+      });
+    } catch (err: any) {
+      throw new Error(`OpenAI API error: ${extractErrorMessage(err)}`);
+    }
 
     const choice = res.data.choices[0];
     const msg = choice.message;

--- a/src/lib/tools/handlers.ts
+++ b/src/lib/tools/handlers.ts
@@ -1,4 +1,5 @@
 import { executeRequest, ExecutionResult } from '../executor/http';
+import { extractErrorMessage } from '../utils/error';
 import { StepEntry, StepRequest, StepCallback } from '../step-log';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -111,16 +112,17 @@ async function callApi(args: Record<string, unknown>, ctx: ToolContext) {
       duration: `${result.duration}ms`,
     };
   } catch (err: any) {
+    const errorMessage = extractErrorMessage(err);
     const step: StepEntry = {
       stepNumber: ++ctx.stepCount,
       toolName: 'call_api',
       request: stepRequest,
-      error: err.message,
+      error: errorMessage,
       timestamp: Date.now(),
     };
     ctx.steps.push(step);
     ctx.onStep?.(step);
-    return { error: err.message };
+    return { error: errorMessage };
   }
 }
 

--- a/src/lib/utils/error.ts
+++ b/src/lib/utils/error.ts
@@ -1,0 +1,21 @@
+/**
+ * Extract the most useful error message from any error, with special handling for axios errors.
+ * Priority: err.response.data.error.message → JSON.stringify(err.response.data) → err.message
+ */
+export function extractErrorMessage(err: any): string {
+  if (err?.response?.data) {
+    const data = err.response.data;
+    if (data?.error?.message) {
+      return `${data.error.type ? data.error.type + ': ' : ''}${data.error.message}`;
+    }
+    if (typeof data === 'string') {
+      return data;
+    }
+    try {
+      return JSON.stringify(data);
+    } catch {
+      // fall through
+    }
+  }
+  return err?.message || String(err);
+}


### PR DESCRIPTION
## Problem
When LLM API calls fail, axios errors were caught but only `err.message` was displayed — giving generic messages like "Request failed with status code 401" instead of the actual API error details in `err.response.data`.

## Changes
- **New helper** `src/lib/utils/error.ts` — `extractErrorMessage()` consistently extracts the best error message from any error (axios or otherwise), preferring `err.response.data.error.message` → `JSON.stringify(err.response.data)` → `err.message`
- **Claude adapter** — wraps axios errors with meaningful messages including API response body
- **OpenAI adapter** — same treatment
- **call_api handler** — uses `extractErrorMessage` for better error reporting in step logs
- **CLI test command** — displays full error details from API responses