### PR TITLE
feat(US-13): interactive test mode with clarification loop

### DIFF
--- a/src/cli/commands/test.ts
+++ b/src/cli/commands/test.ts
@@ -1,3 +1,4 @@
+import * as readline from 'readline';
 import { loadConfig } from '../../lib/config';
 import { createAdapter } from '../../lib/adapters/factory';
 import { AgentCore } from '../../lib/agent/core';
@@ -39,10 +40,24 @@ export async function runTest(args: string[]): Promise<void> {
 
   const formatOpts: FormatOptions = { verbose, maxBodyChars: 500 };
 
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  const onAskUser = (question: string): Promise<string> => {
+    return new Promise((resolve) => {
+      rl.question(`\n🤖 Agent asks: ${question}\n> `, (answer) => {
+        resolve(answer);
+      });
+    });
+  };
+
   const agent = new AgentCore(adapter, {
     baseUrl: config.target.baseUrl,
     auth: config.target.auth,
     knowledgeDir: config.knowledge?.dir,
+    onAskUser,
     onStep: (step) => {
       console.log(formatStep(step, formatOpts));
     },
@@ -80,5 +95,7 @@ export async function runTest(args: string[]): Promise<void> {
   } catch (err: any) {
     console.error(`\n❌ Error: ${extractErrorMessage(err)}`);
     process.exit(1);
+  } finally {
+    rl.close();
   }
 }

--- a/src/lib/agent/core.ts
+++ b/src/lib/agent/core.ts
@@ -10,6 +10,7 @@ export interface AgentConfig {
   auth?: { type: string; token?: string; header?: string };
   knowledgeDir?: string;
   onStep?: StepCallback;
+  onAskUser?: (question: string) => Promise<string>;
 }
 
 export class AgentCore {
@@ -31,6 +32,7 @@ export class AgentCore {
       stepCount: 0,
       steps: [],
       onStep: config.onStep,
+      onAskUser: config.onAskUser,
     };
     this.history.push({ role: 'system', content: this.buildSystemPrompt() });
   }

--- a/src/lib/agent/prompts.ts
+++ b/src/lib/agent/prompts.ts
@@ -24,9 +24,10 @@ Use **read_knowledge** only when you need:
 - Detailed enum values, validation rules, or nested object structures
 
 Use **ask_user** when:
+- The user's test scenario is unclear or ambiguous
 - The spec doesn't contain enough info to proceed (e.g. missing auth credentials, ambiguous endpoints)
-- The user's request is unclear and you need clarification
 - You need specific test data that can't be generated
+- If the scenario is clear and specific, proceed immediately without asking
 
 ## Rules
 - Generate realistic test data (names, emails, etc.) — don't use obvious fakes like "test123"

--- a/src/lib/tools/handlers.ts
+++ b/src/lib/tools/handlers.ts
@@ -3,8 +3,6 @@ import { extractErrorMessage } from '../utils/error';
 import { StepEntry, StepRequest, StepCallback } from '../step-log';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as readline from 'readline';
-
 export interface ToolContext {
   baseUrl: string;
   auth?: { type: string; token?: string; header?: string };
@@ -16,6 +14,7 @@ export interface ToolContext {
   stepCount: number;
   steps: StepEntry[];
   onStep?: StepCallback;
+  onAskUser?: (question: string) => Promise<string>;
 }
 
 export interface TestResult {
@@ -293,18 +292,12 @@ async function askUser(args: Record<string, unknown>, ctx: ToolContext) {
   ctx.steps.push(step);
   ctx.onStep?.(step);
 
-  // Prompt via stdin
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
+  if (!ctx.onAskUser) {
+    return { error: 'Interactive mode not available — no onAskUser callback configured' };
+  }
 
-  return new Promise<{ answer: string }>((resolve) => {
-    rl.question(`\n🤖 Agent asks: ${question}\n> `, (answer) => {
-      rl.close();
-      resolve({ answer: answer.trim() });
-    });
-  });
+  const answer = await ctx.onAskUser(question);
+  return { answer: answer.trim() };
 }
 
 function reportResult(args: Record<string, unknown>, ctx: ToolContext) {


### PR DESCRIPTION
## Summary

Add an `onAskUser` callback pattern to enable interactive clarification during test runs. The agent can now ask the user questions via the `ask_user` tool before proceeding with test execution.

### Changes

- **`src/lib/tools/handlers.ts`**: Added `onAskUser` to `ToolContext`, refactored `ask_user` handler to use callback instead of raw readline
- **`src/lib/agent/core.ts`**: Added `onAskUser` to `AgentConfig`, passed through to `ToolContext`
- **`src/lib/agent/prompts.ts`**: Updated system prompt with clearer guidance on when to use `ask_user`
- **`src/cli/commands/test.ts`**: Creates readline interface and passes `onAskUser` callback to AgentCore

Closes #14