### PR TITLE
fix: use Bearer auth header for OAuth token mode

### DIFF
--- a/src/cli/commands/test.ts
+++ b/src/cli/commands/test.ts
@@ -36,7 +36,7 @@ export async function runTest(args: string[]): Promise<void> {
   const providerMap = { anthropic: 'claude' as const, openai: 'openai' as const };
   config.llm.provider = providerMap[credentials.provider] || config.llm.provider;
   config.llm.apiKey = getResolvedApiKey(credentials);
-  const adapter = createAdapter(config.llm.provider, config.llm.apiKey, config.llm.model);
+  const adapter = createAdapter(config.llm.provider, config.llm.apiKey, config.llm.model, credentials.authMode);
 
   const formatOpts: FormatOptions = { verbose, maxBodyChars: 500 };
 

--- a/src/lib/adapters/claude.ts
+++ b/src/lib/adapters/claude.ts
@@ -5,10 +5,12 @@ import { extractErrorMessage } from '../utils/error';
 export class ClaudeAdapter implements LLMAdapter {
   private apiKey: string;
   private model: string;
+  private authMode: 'api-key' | 'oauth-token';
 
-  constructor(apiKey: string, model: string = 'claude-sonnet-4-20250514') {
+  constructor(apiKey: string, model: string = 'claude-sonnet-4-20250514', authMode: 'api-key' | 'oauth-token' = 'api-key') {
     this.apiKey = apiKey;
     this.model = model;
+    this.authMode = authMode;
   }
 
   async chat(messages: LLMMessage[]): Promise<LLMResponse> {
@@ -39,7 +41,9 @@ export class ClaudeAdapter implements LLMAdapter {
     try {
       res = await axios.post('https://api.anthropic.com/v1/messages', body, {
         headers: {
-          'x-api-key': this.apiKey,
+          ...(this.authMode === 'oauth-token'
+            ? { 'Authorization': 'Bearer ' + this.apiKey }
+            : { 'x-api-key': this.apiKey }),
           'anthropic-version': '2023-06-01',
           'Content-Type': 'application/json',
         },

--- a/src/lib/adapters/factory.ts
+++ b/src/lib/adapters/factory.ts
@@ -2,12 +2,12 @@ import { LLMAdapter } from './interface';
 import { OpenAIAdapter } from './openai';
 import { ClaudeAdapter } from './claude';
 
-export function createAdapter(provider: string, apiKey: string, model: string): LLMAdapter {
+export function createAdapter(provider: string, apiKey: string, model: string, authMode?: 'api-key' | 'oauth-token'): LLMAdapter {
   switch (provider) {
     case 'openai':
       return new OpenAIAdapter(apiKey, model);
     case 'claude':
-      return new ClaudeAdapter(apiKey, model);
+      return new ClaudeAdapter(apiKey, model, authMode);
     case 'gemini':
       throw new Error('Gemini adapter not yet implemented');
     default:


### PR DESCRIPTION
## Problem
When `authMode` is `oauth-token`, the Claude adapter sends `x-api-key` header instead of `Authorization: Bearer <token>`, causing `authentication_error: invalid x-api-key`.

## Fix
- `ClaudeAdapter` now accepts an `authMode` parameter (`'api-key'` | `'oauth-token'`)
- Headers are set based on authMode: `x-api-key` for API key mode, `Authorization: Bearer` for OAuth token mode
- `createAdapter` factory passes `authMode` through to `ClaudeAdapter`
- `test.ts` passes `credentials.authMode` to the factory

## Files Changed
- `src/lib/adapters/claude.ts` — authMode-aware header selection
- `src/lib/adapters/factory.ts` — accepts optional `authMode` param
- `src/cli/commands/test.ts` — passes `credentials.authMode` to factory