### PR TITLE
feat(US-14): add Claude Code adapter for OAuth token users

### DIFF
--- a/src/cli/commands/test.ts
+++ b/src/cli/commands/test.ts
@@ -36,7 +36,13 @@ export async function runTest(args: string[]): Promise<void> {
   const providerMap = { anthropic: 'claude' as const, openai: 'openai' as const };
   config.llm.provider = providerMap[credentials.provider] || config.llm.provider;
   config.llm.apiKey = getResolvedApiKey(credentials);
-  const adapter = createAdapter(config.llm.provider, config.llm.apiKey, config.llm.model, credentials.authMode);
+  const adapter = createAdapter(
+    config.llm.provider,
+    config.llm.apiKey,
+    config.llm.model,
+    credentials.authMode,
+    { baseUrl: config.target.baseUrl, auth: config.target.auth },
+  );
 
   const formatOpts: FormatOptions = { verbose, maxBodyChars: 500 };
 

--- a/src/lib/adapters/claude-code.ts
+++ b/src/lib/adapters/claude-code.ts
@@ -1,0 +1,129 @@
+import { execSync, execFileSync } from 'child_process';
+import { LLMAdapter, LLMMessage, LLMResponse, ToolDefinition } from './interface';
+
+export interface ClaudeCodeContext {
+  baseUrl: string;
+  auth?: { type: string; token?: string; header?: string };
+}
+
+const RESULTS_MARKER = 'ANVIL_RESULTS_JSON:';
+
+export class ClaudeCodeAdapter implements LLMAdapter {
+  private model: string;
+  private context?: ClaudeCodeContext;
+
+  constructor(model: string = 'sonnet', context?: ClaudeCodeContext) {
+    // Verify claude CLI is available
+    try {
+      execSync('claude --version', { stdio: 'pipe' });
+    } catch {
+      throw new Error('Claude Code CLI not found. Install it: npm install -g @anthropic-ai/claude-code');
+    }
+    this.model = model;
+    this.context = context;
+  }
+
+  setContext(context: ClaudeCodeContext): void {
+    this.context = context;
+  }
+
+  async chat(messages: LLMMessage[]): Promise<LLMResponse> {
+    return this.chatWithTools(messages, []);
+  }
+
+  async chatWithTools(messages: LLMMessage[], _tools: ToolDefinition[]): Promise<LLMResponse> {
+    const systemMsg = messages.find(m => m.role === 'system');
+    const userMsgs = messages.filter(m => m.role !== 'system');
+
+    // Build system prompt with API context
+    let systemPrompt = systemMsg?.content || '';
+    if (this.context) {
+      systemPrompt += `\n\n## API Target Configuration
+- Base URL: ${this.context.baseUrl}
+${this.context.auth ? `- Authentication: Use header "${this.context.auth.header || 'Authorization'}: ${this.context.auth.token || ''}"` : '- Authentication: None configured'}
+
+## Instructions
+- Use \`curl\` to make HTTP requests to the API
+- Always include appropriate headers (Content-Type: application/json, auth headers)
+- Test the scenarios described by the user
+- After completing all tests, output your results in this EXACT format on its own line:
+${RESULTS_MARKER}{"results":[{"testName":"...","status":"pass|fail|warn","message":"..."}],"steps":[],"message":"summary"}
+
+The ANVIL_RESULTS_JSON line must be valid JSON after the marker. Include all test results.`;
+    }
+
+    // Build user prompt from conversation
+    const userPrompt = userMsgs
+      .map(m => `[${m.role}]: ${m.content}`)
+      .join('\n\n');
+
+    // Spawn claude -p
+    const args = [
+      '-p',
+      '--output-format', 'json',
+      '--model', this.model,
+      '--dangerously-skip-permissions',
+      '--allowedTools', 'Bash(curl:*)',
+      userPrompt,
+    ];
+
+    if (systemPrompt) {
+      args.splice(1, 0, '--system-prompt', systemPrompt);
+    }
+
+    let output: string;
+    try {
+      output = execFileSync('claude', args, {
+        encoding: 'utf-8',
+        maxBuffer: 10 * 1024 * 1024,
+        timeout: 5 * 60 * 1000, // 5 min
+      });
+    } catch (err: any) {
+      throw new Error(`Claude Code CLI error: ${err.message}`);
+    }
+
+    // Parse JSON output
+    let resultText: string;
+    try {
+      const parsed = JSON.parse(output);
+      resultText = parsed.result || parsed.content || output;
+    } catch {
+      resultText = output;
+    }
+
+    // Extract parsed results
+    const parsedResults = this.extractResults(resultText);
+
+    // Strip the marker line from content
+    const cleanContent = resultText
+      .split('\n')
+      .filter((line: string) => !line.includes(RESULTS_MARKER))
+      .join('\n')
+      .trim();
+
+    return {
+      content: cleanContent,
+      parsedResults: parsedResults.length > 0 ? parsedResults : undefined,
+    };
+  }
+
+  private extractResults(text: string): { testName: string; status: 'pass' | 'fail' | 'warn'; message?: string }[] {
+    const idx = text.indexOf(RESULTS_MARKER);
+    if (idx === -1) return [];
+
+    const jsonStr = text.substring(idx + RESULTS_MARKER.length).split('\n')[0].trim();
+    try {
+      const data = JSON.parse(jsonStr);
+      if (Array.isArray(data.results)) {
+        return data.results.map((r: any) => ({
+          testName: r.testName || 'Unknown',
+          status: (['pass', 'fail', 'warn'].includes(r.status) ? r.status : 'warn') as 'pass' | 'fail' | 'warn',
+          message: r.message,
+        }));
+      }
+    } catch {
+      // Failed to parse results
+    }
+    return [];
+  }
+}

--- a/src/lib/adapters/factory.ts
+++ b/src/lib/adapters/factory.ts
@@ -1,12 +1,22 @@
 import { LLMAdapter } from './interface';
 import { OpenAIAdapter } from './openai';
 import { ClaudeAdapter } from './claude';
+import { ClaudeCodeAdapter, ClaudeCodeContext } from './claude-code';
 
-export function createAdapter(provider: string, apiKey: string, model: string, authMode?: 'api-key' | 'oauth-token'): LLMAdapter {
+export function createAdapter(
+  provider: string,
+  apiKey: string,
+  model: string,
+  authMode?: 'api-key' | 'oauth-token',
+  claudeCodeContext?: ClaudeCodeContext,
+): LLMAdapter {
   switch (provider) {
     case 'openai':
       return new OpenAIAdapter(apiKey, model);
     case 'claude':
+      if (authMode === 'oauth-token') {
+        return new ClaudeCodeAdapter(model, claudeCodeContext);
+      }
       return new ClaudeAdapter(apiKey, model, authMode);
     case 'gemini':
       throw new Error('Gemini adapter not yet implemented');

--- a/src/lib/adapters/interface.ts
+++ b/src/lib/adapters/interface.ts
@@ -14,6 +14,7 @@ export interface ToolCall {
 export interface LLMResponse {
   content: string;
   toolCalls?: ToolCall[];
+  parsedResults?: { testName: string; status: 'pass' | 'fail' | 'warn'; message?: string }[];
 }
 
 export interface LLMAdapter {

--- a/src/lib/agent/core.ts
+++ b/src/lib/agent/core.ts
@@ -64,6 +64,14 @@ export class AgentCore {
 
       if (!response.toolCalls?.length) {
         this.history.push({ role: 'assistant', content: response.content });
+
+        // Merge parsed results from single-shot adapters (e.g. ClaudeCodeAdapter)
+        if (response.parsedResults?.length) {
+          for (const r of response.parsedResults) {
+            this.toolContext.results.push(r);
+          }
+        }
+
         return {
           message: response.content,
           results: this.toolContext.results,


### PR DESCRIPTION
## Summary

Adds a new `ClaudeCodeAdapter` that uses the Claude Code CLI (`claude -p`) as the LLM backend for users with `oauth-token` auth mode, since the Anthropic API doesn't support OAuth tokens directly.

## Changes

- **`src/lib/adapters/claude-code.ts`** — New adapter that spawns `claude -p` with system prompt containing API context, parses structured results from `ANVIL_RESULTS_JSON:` marker
- **`src/lib/adapters/interface.ts`** — Added optional `parsedResults` field to `LLMResponse`
- **`src/lib/adapters/factory.ts`** — Routes `oauth-token` auth mode to `ClaudeCodeAdapter`; accepts optional context parameter
- **`src/lib/agent/core.ts`** — Merges `parsedResults` from single-shot adapters into tool context results
- **`src/cli/commands/test.ts`** — Passes `baseUrl` and `auth` config to adapter factory

## How it works

The adapter collapses the multi-turn tool loop into a single Claude Code invocation. Claude Code uses its own Bash tool to make curl requests and reports results in a structured JSON format. The agent loop gets a response with no tool calls and returns immediately.

Closes #17